### PR TITLE
feat: expand Mimi lesson schema

### DIFF
--- a/app/mimi.py
+++ b/app/mimi.py
@@ -37,9 +37,14 @@ Return STRICT JSON ONLY with EXACTLY these keys:
   "title": "string",
   "duration": "string (e.g., '30 min')",
   "objectives": ["string", "..."],
-  "plan": [
-    { "name": "string", "minutes": "string or number", "teacher_script": "string" }
-  ],
+  "materials": ["string", "..."],
+  "warm_up": { "name": "string", "minutes": "string or number", "teacher_script": "string" },
+  "vocab_cards": { "name": "string", "minutes": "string or number", "teacher_script": "string" },
+  "mini_story": { "name": "string", "minutes": "string or number", "teacher_script": "string" },
+  "phonics_focus": { "name": "string", "minutes": "string or number", "teacher_script": "string" },
+  "practice": { "name": "string", "minutes": "string or number", "teacher_script": "string" },
+  "wrap_up": { "name": "string", "minutes": "string or number", "teacher_script": "string" },
+  "homework": { "name": "string", "minutes": "string or number", "teacher_script": "string" },
   "image_prompts": [
     { "id": "string", "prompt": "string" }
   ],
@@ -50,9 +55,12 @@ Rules:
 - No extra keys.
 - No code fences.
 - No prose outside JSON.
+- Objectives: 2–3 short bullet points.
+- Provide a materials list for the teacher.
 - Make language simple and encouraging; short sentences; playful tone.
 - Include speaking aloud, call-and-response, mini-games, and a creative wrap-up.
 - Provide 5–8 kid-safe image prompts (no brands, no text in-image, no real faces).
+- Use image prompt IDs like "cover_scene", "vocab_card_<word>", "story_frame", "phonics_poster", "reward_sticker".
 """
 
 def _normalize_to_strict_schema(obj: Dict[str, Any]) -> Dict[str, Any]:
@@ -75,11 +83,48 @@ def _normalize_to_strict_schema(obj: Dict[str, Any]) -> Dict[str, Any]:
     objectives = obj.get("objectives") or []
     if not isinstance(objectives, list):
         objectives = [str(objectives)]
+    if len(objectives) < 2 or len(objectives) > 3:
+        raise ValueError("Expected 2-3 objectives")
+
+    materials = obj.get("materials") or obj.get("material_list") or []
+    if isinstance(materials, str):
+        materials = [materials]
+    if not isinstance(materials, list):
+        materials = [str(materials)]
+    if not materials:
+        raise ValueError("Materials list required")
+
+    def _norm_activity(key: str) -> Dict[str, str]:
+        raw = obj.get(key) or {}
+        if not isinstance(raw, dict):
+            raw = {}
+        name = raw.get("name") or raw.get("title") or key.replace("_", " ").title()
+        minutes = raw.get("minutes") or raw.get("duration") or raw.get("duration_minutes") or ""
+        if isinstance(minutes, (int, float)):
+            minutes = str(int(minutes))
+        teacher_script = (
+            raw.get("teacher_script")
+            or raw.get("script")
+            or (" • ".join(raw.get("steps", [])) if isinstance(raw.get("steps"), list) else raw.get("description"))
+            or ""
+        )
+        return {"name": name, "minutes": minutes, "teacher_script": teacher_script}
+
+    activity_keys = [
+        "warm_up",
+        "vocab_cards",
+        "mini_story",
+        "phonics_focus",
+        "practice",
+        "wrap_up",
+        "homework",
+    ]
+    activities = {k: _norm_activity(k) for k in activity_keys}
 
     # plan normalization
     plan_in = obj.get("plan") or obj.get("activities") or obj.get("sections") or []
     plan_out: List[Dict[str, Any]] = []
-    if isinstance(plan_in, list):
+    if isinstance(plan_in, list) and plan_in:
         for step in plan_in:
             if not isinstance(step, dict):
                 continue
@@ -94,6 +139,11 @@ def _normalize_to_strict_schema(obj: Dict[str, Any]) -> Dict[str, Any]:
                 or ""
             )
             plan_out.append({"name": name, "minutes": minutes, "teacher_script": teacher_script})
+    else:
+        for key in activity_keys:
+            act = activities.get(key)
+            if act.get("teacher_script") or act.get("minutes"):
+                plan_out.append(act)
 
     # image prompts normalization
     image_prompts_in = obj.get("image_prompts") or obj.get("imagePrompts") or obj.get("slides") or []
@@ -110,15 +160,17 @@ def _normalize_to_strict_schema(obj: Dict[str, Any]) -> Dict[str, Any]:
     first_tutor_messages = obj.get("first_tutor_messages") or obj.get("firstTutorMessages") or []
     if not isinstance(first_tutor_messages, list) or not first_tutor_messages:
         first_tutor_messages = [f"Bonjour ! {title}"]
-
-    return {
+    result: Dict[str, Any] = {
         "title": title,
         "duration": duration,
         "objectives": objectives,
+        "materials": materials,
         "plan": plan_out,
         "image_prompts": image_prompts,
         "first_tutor_messages": first_tutor_messages,
     }
+    result.update(activities)
+    return result
 
 def _extract_json_loose(text: str) -> Dict[str, Any]:
     """As a last resort, try to find the outermost JSON object in text."""
@@ -134,23 +186,56 @@ def _extract_json_loose(text: str) -> Dict[str, Any]:
 def _chat_json_strict(payload: Dict[str, Any]) -> Dict[str, Any]:
     # Demo path if no key or no client
     if not OPENAI_API_KEY or openai_client is None:
-        return {
+        demo = {
             "title": "Démo — Les symboles de la France",
             "duration": "30 min",
-            "objectives": ["Reconnaître quelques symboles", "Dire 'C’est ...'"],
-            "plan": [
-                {"name": "Échauffement — Devine l’image", "minutes": "5", "teacher_script": "Regarde l’image. Qu’est-ce que c’est ? Répète : C’est un croissant !"},
-                {"name": "Jeu — Associer", "minutes": "8", "teacher_script": "Associe la photo au mot. Répète ensemble."},
-                {"name": "Découverte — Carte du monde", "minutes": "7", "teacher_script": "On parle français dans plusieurs pays."},
-                {"name": "Jeu de rôle — Guide & Touriste", "minutes": "6", "teacher_script": "Tu es le guide, je suis le touriste."},
-                {"name": "Créatif — Dessin", "minutes": "4", "teacher_script": "Dessine ton symbole préféré et dis : C’est ..."}
-            ],
+            "objectives": ["Reconnaître quelques symboles", "Dire 'C’est ...'"] ,
+            "materials": ["Images imprimées", "Crayons"],
+            "warm_up": {
+                "name": "Échauffement — Devine l’image",
+                "minutes": "5",
+                "teacher_script": "Regarde l’image. Qu’est-ce que c’est ? Répète : C’est un croissant !"
+            },
+            "vocab_cards": {
+                "name": "Cartes de vocabulaire",
+                "minutes": "8",
+                "teacher_script": "Associe la photo au mot. Répète ensemble."
+            },
+            "mini_story": {
+                "name": "Découverte — Carte du monde",
+                "minutes": "7",
+                "teacher_script": "On parle français dans plusieurs pays."
+            },
+            "phonics_focus": {
+                "name": "Sons — 'ou'",
+                "minutes": "4",
+                "teacher_script": "Écoute et répète le son 'ou' comme dans 'bonjour'."
+            },
+            "practice": {
+                "name": "Jeu de rôle — Guide & Touriste",
+                "minutes": "6",
+                "teacher_script": "Tu es le guide, je suis le touriste."
+            },
+            "wrap_up": {
+                "name": "Créatif — Dessin",
+                "minutes": "4",
+                "teacher_script": "Dessine ton symbole préféré et dis : C’est ..."
+            },
+            "homework": {
+                "name": "À la maison",
+                "minutes": "0",
+                "teacher_script": "Montre un symbole français à ta famille et dis : C’est ..."
+            },
             "image_prompts": [
-                {"id":"img1","prompt":"Kid-friendly illustration of the Eiffel Tower, bright colors, no text, no real faces, teaching style"},
-                {"id":"img2","prompt":"Croissant on a small plate, friendly illustration, simple shapes, no text"}
+                {"id": "cover_scene", "prompt": "Kid-friendly illustration of the Eiffel Tower, bright colors, no text, no real faces"},
+                {"id": "vocab_card_croissant", "prompt": "Simple drawing of a croissant on a plate, no text"},
+                {"id": "story_frame", "prompt": "Children looking at a world map with France highlighted, cartoon style"},
+                {"id": "phonics_poster", "prompt": "Poster showing the French letters 'ou' with a smiling mouth diagram"},
+                {"id": "reward_sticker", "prompt": "Cute gold star sticker with a smiley face, flat design"}
             ],
             "first_tutor_messages": ["Bonjour ! Prêt(e) ? On commence avec un jeu de devinettes !"]
         }
+        return _normalize_to_strict_schema(demo)
 
     # Trim long text defensively
     payload = dict(payload)


### PR DESCRIPTION
## Summary
- request richer lesson structure in Mimi system prompt
- normalize new lesson fields and require materials plus 2-3 objectives
- update demo path to match new schema

## Testing
- `python -m py_compile app/mimi.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c274ff15348327a2e0249b7a915f4d