### PR TITLE
feat: expand lesson preview and materials

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -175,6 +175,16 @@ $("#btnBuild").addEventListener("click", async () => {
       });
       preview.appendChild(ul);
     }
+    if (Array.isArray(data.lesson.materials)) {
+      const mHead = document.createElement("h4");
+      mHead.textContent = "Matériel";
+      preview.appendChild(mHead);
+      const ml = document.createElement("ul");
+      data.lesson.materials.forEach((m) => {
+        const li = document.createElement("li"); li.textContent = m; ml.appendChild(li);
+      });
+      preview.appendChild(ml);
+    }
     syncLessonEl.innerHTML = "";
     syncLessonEl.appendChild(preview);
 


### PR DESCRIPTION
## Summary
- expand build_mimi_lesson to normalize materials and preview warm-up, vocabulary, mini-story, phonics, practice and wrap-up sections
- render materials list in the web preview so required items are visible

## Testing
- `python -m py_compile app/mimi.py`
- `node --check app/static/app.js`


------
https://chatgpt.com/codex/tasks/task_e_68c275ff65d4832795689f8119a335a0