### PR TITLE
Add OCR image description extraction

### DIFF
--- a/tests/test_extract_image_descriptions.py
+++ b/tests/test_extract_image_descriptions.py
@@ -1,0 +1,16 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from app.tasks import extract_image_descriptions
+
+
+def test_extract_image_descriptions_frequency():
+    text = (
+        "Un chat noir et un chien marron dans une ville. "
+        "Le chat regarde la ville. La ville est belle."
+    )
+    result = extract_image_descriptions(text, max_items=3)
+    assert result[:2] == ["ville", "chat"]
+    assert len(result) == 3


### PR DESCRIPTION
## Summary
- parse OCR text for frequent keywords via `extract_image_descriptions`
- feed extracted descriptions into `build_mimi_lesson`
- test keyword extraction helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c276e38c708327baf4e0819ab64f00