### PR TITLE
Trigger image generation automatically after lesson build

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -192,6 +192,7 @@ $("#btnBuild").addEventListener("click", async () => {
       renderUiSteps(syncLessonEl, data.lesson.ui_steps);
     }
     setStatus("✅ Leçon prête");
+    $("#btnGenImgs").click();
   } catch (e) {
     setStatus("❌ " + e.message);
   }


### PR DESCRIPTION
## Summary
- Auto-trigger image generation once a Mimi lesson finishes building.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2917463288327b7894437476091d2