### PR TITLE
Use Mimi lesson builder and drop manual JSON parsing

### DIFF
--- a/app/tasks.py
+++ b/app/tasks.py
@@ -1,5 +1,5 @@
 # app/tasks.py
-import os, json, requests, logging, re
+import os, requests, logging, re
 from collections import Counter
 from datetime import datetime
 from typing import Optional
@@ -62,17 +62,6 @@ def _public_storage_url(path: str) -> str:
     # Avoid double-encoding existing %xx
     safe_path = quote(path.lstrip("/"), safe="/%")
     return f"{base}/{safe_path}"
-
-def _json_loose(text: str):
-    """Extract outermost JSON object if model returns stray characters."""
-    try:
-        return json.loads(text)
-    except Exception:
-        start = text.find("{"); end = text.rfind("}")
-        if start != -1 and end != -1 and end > start:
-            return json.loads(text[start:end+1])
-        raise
-
 
 def extract_image_descriptions(text: str, max_items: int = 5) -> list[str]:
     """Return key nouns/scene hints from OCR text using simple frequency analysis."""


### PR DESCRIPTION
## Summary
- call `mimi.build_mimi_lesson` in build script to generate full lesson objects
- remove unused manual JSON parsing helper

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c2f9369b048327a6f385487161b53b