### PR TITLE
Add lesson card renderer with TTS support

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -63,6 +63,8 @@
       <div id="imageTabs" class="image-tabs"></div>
     </section>
 
+    <section id="lessonView" class="lesson-grid"></section>
+
     <!-- Tutor chat -->
     <section class="card">
       <h2>Chat avec Mimi</h2>

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -72,3 +72,15 @@ textarea{ resize:vertical }
 
 footer{ text-align:center; margin:16px 0 }
 .muted{ color:var(--muted) }
+
+.lesson-grid { display: grid; grid-template-columns: repeat(auto-fit,minmax(280px,1fr)); gap: 14px; margin-top: 14px; }
+.card { background:#fff; border-radius:16px; box-shadow:0 6px 20px rgba(0,0,0,.08); padding:16px; }
+.card h3 { margin:0 0 8px; font-size:1.1rem; }
+.card p { margin:8px 0; line-height:1.4; }
+.card img { width:100%; height:180px; object-fit:contain; background:#f7f7f9; border-radius:12px; }
+.row { display:flex; gap:8px; flex-wrap:wrap; align-items:center; }
+.badge { background:#eef2ff; color:#3730a3; border-radius:999px; padding:4px 10px; font-size:.85rem; }
+.tts { border:none; border-radius:999px; padding:8px 12px; cursor:pointer; }
+.tts.slow { background:#e0f7ec; }
+.tts.normal { background:#e6f0ff; }
+.small { font-size:.9rem; color:#555; }


### PR DESCRIPTION
## Summary
- Add lessonView container for rendering lesson cards
- Append CSS rules for card grid, TTS buttons, and badges
- Implement renderLessonCards with speech synthesis and integrate into lesson flow

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c30a76a12c832793caf1c6fe2a0a87