### PR TITLE
Add quiz support to Mimi lessons

### DIFF
--- a/tests/test_quiz_ui_steps.py
+++ b/tests/test_quiz_ui_steps.py
@@ -1,0 +1,19 @@
+import os
+import sys
+
+# Ensure demo mode (no API key)
+os.environ["OPENAI_API_KEY"] = ""
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from app import mimi
+
+# Force demo path regardless of environment
+mimi.openai_client = None
+build_mimi_lesson = mimi.build_mimi_lesson
+
+
+def test_quiz_adds_question_block_to_ui_steps():
+    lesson = build_mimi_lesson()
+    question_blocks = [s for s in lesson["ui_steps"] if s.get("type") == "question"]
+    assert question_blocks, "Expected at least one question block in ui_steps"


### PR DESCRIPTION
## Summary
- request a `quiz` array in Mimi's system prompt and enforce generation of simple multiple-choice questions
- parse and return `quiz` entries during lesson normalization and include demo quiz data
- append quiz questions to `ui_steps` and test that question blocks appear when quiz data exists

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c395075b9c83279df56d3863c65910