### PR TITLE
Use UUID identifiers for lessons

### DIFF
--- a/app/tasks.py
+++ b/app/tasks.py
@@ -1,5 +1,5 @@
 # app/tasks.py
-import os, requests, logging, re
+import os, requests, logging, re, uuid
 from collections import Counter
 from datetime import datetime
 from typing import Optional
@@ -109,7 +109,8 @@ def api_lessons():
         lesson = supabase.table("lessons").insert(lesson_rec).execute()
         lesson_id = lesson.data[0]["id"]
     else:
-        lesson_id = "dev-lesson-id"
+        # Use a UUID string locally to mirror production IDs
+        lesson_id = str(uuid.uuid4())
 
     # Enqueue Celery job
     try:

--- a/build.sh
+++ b/build.sh
@@ -8,6 +8,7 @@ mkdir -p app
 cat > app/main.py <<'PYEOF'
 import os
 import json
+import uuid
 from flask import Flask, request, jsonify
 from flask_cors import CORS
 from supabase import create_client, Client
@@ -63,7 +64,11 @@ def api_lessons():
         "uploaded_file_path": file_path,
         "status": "processing"
     }
-    lesson = supabase.table("lessons").insert(lesson_rec).execute() if supabase else type("X",(object,),{"data":[{"id":"dev-lesson-id"}]})()
+    lesson = (
+        supabase.table("lessons").insert(lesson_rec).execute()
+        if supabase
+        else type("X", (object,), {"data": [{"id": str(uuid.uuid4())}]})()
+    )
     lesson_id = lesson.data[0]["id"]
 
     # Enqueue Celery job

--- a/supabase/migrations/20240813000000_change_lessons_id_to_uuid.sql
+++ b/supabase/migrations/20240813000000_change_lessons_id_to_uuid.sql
@@ -1,0 +1,15 @@
+-- Convert lessons.id to UUID and update related references
+ALTER TABLE lessons
+  ALTER COLUMN id DROP DEFAULT,
+  ALTER COLUMN id TYPE uuid USING id::uuid,
+  ALTER COLUMN id SET DEFAULT gen_random_uuid(),
+  ALTER COLUMN id SET NOT NULL;
+
+-- Update embeddings references
+ALTER TABLE embeddings
+  DROP CONSTRAINT IF EXISTS embeddings_lesson_id_fkey,
+  ALTER COLUMN lesson_id TYPE uuid USING lesson_id::uuid;
+
+ALTER TABLE embeddings
+  ADD CONSTRAINT embeddings_lesson_id_fkey FOREIGN KEY (lesson_id)
+  REFERENCES lessons (id) ON DELETE CASCADE;


### PR DESCRIPTION
## Summary
- migrate lessons table ID to UUID and update embeddings lesson_id reference
- ensure dev environment uses UUID strings for lesson IDs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c398eec4408327b6c0feb2aa394800