### PR TITLE
Enforce UUID child_id for lessons

### DIFF
--- a/app/static/app.js
+++ b/app/static/app.js
@@ -223,6 +223,12 @@ $("#btnAsync").addEventListener("click", async () => {
     return;
   }
 
+  const uuidRe = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+  if (!uuidRe.test(child_id)) {
+    setStatus("❌ child_id doit être un UUID valide");
+    return;
+  }
+
   setStatus("🚀 Envoi du job…");
   try {
     const res = await fetch("/api/lessons", {

--- a/app/tasks.py
+++ b/app/tasks.py
@@ -90,6 +90,12 @@ def api_lessons():
     if not child_id or not file_path:
         return jsonify(ok=False, error="child_id and file_path are required"), 400
 
+    # Ensure child_id is a valid UUID
+    try:
+        child_id = str(uuid.UUID(str(child_id)))
+    except (ValueError, TypeError):
+        return jsonify(ok=False, error="child_id must be a valid UUID"), 400
+
     # Optional auth check
     user_id = _get_user_id_from_auth()
     if user_id and supabase:

--- a/build.sh
+++ b/build.sh
@@ -49,6 +49,12 @@ def api_lessons():
     if not child_id or not file_path:
         return jsonify(ok=False, error="child_id and file_path are required"), 400
 
+    # Ensure child_id is a valid UUID
+    try:
+        child_id = str(uuid.UUID(str(child_id)))
+    except (ValueError, TypeError):
+        return jsonify(ok=False, error="child_id must be a valid UUID"), 400
+
     # Optional auth check against children table
     user_id = _get_user_id_from_auth()
     if user_id and supabase:

--- a/supabase/migrations/20240813010000_update_lessons_child_id_to_uuid.sql
+++ b/supabase/migrations/20240813010000_update_lessons_child_id_to_uuid.sql
@@ -1,0 +1,9 @@
+-- Convert lessons.child_id to UUID and add foreign key
+ALTER TABLE lessons
+  DROP CONSTRAINT IF EXISTS lessons_child_id_fkey,
+  ALTER COLUMN child_id TYPE uuid USING child_id::uuid,
+  ALTER COLUMN child_id SET NOT NULL;
+
+ALTER TABLE lessons
+  ADD CONSTRAINT lessons_child_id_fkey FOREIGN KEY (child_id)
+    REFERENCES public.children(id);

--- a/tests/test_lessons_child_id_uuid.py
+++ b/tests/test_lessons_child_id_uuid.py
@@ -1,0 +1,38 @@
+import uuid
+from flask import Flask
+
+import app.tasks as tasks
+
+
+def create_app():
+    app = Flask(__name__)
+    app.register_blueprint(tasks.bp)
+    tasks.supabase = None
+    return app
+
+
+def test_api_lessons_rejects_non_uuid(monkeypatch):
+    app = create_app()
+    client = app.test_client()
+
+    # Stub Celery delay
+    monkeypatch.setattr(tasks.process_lesson, "delay", lambda *args, **kwargs: None)
+
+    res = client.post("/api/lessons", json={"child_id": "not-uuid", "file_path": "f.pdf"})
+    assert res.status_code == 400
+    assert "UUID" in res.get_json()["error"]
+
+
+def test_api_lessons_accepts_uuid(monkeypatch):
+    app = create_app()
+    client = app.test_client()
+
+    # Stub Celery delay
+    monkeypatch.setattr(tasks.process_lesson, "delay", lambda *args, **kwargs: None)
+
+    child_id = str(uuid.uuid4())
+    res = client.post("/api/lessons", json={"child_id": child_id, "file_path": "f.pdf"})
+    assert res.status_code == 202
+    data = res.get_json()
+    assert data["ok"] is True
+    assert data["lesson_id"]


### PR DESCRIPTION
## Summary
- migrate lessons.child_id to `uuid NOT NULL` and link to `children(id)`
- validate `child_id` as UUID in lesson creation API and client script
- add tests for child_id UUID handling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c399e6e07883279bb59c1ee03b8f36