### PR TITLE
Enforce NOT NULL on foreign keys

### DIFF
--- a/supabase/migrations/20240813030000_enforce_not_null_foreign_keys.sql
+++ b/supabase/migrations/20240813030000_enforce_not_null_foreign_keys.sql
@@ -1,0 +1,12 @@
+-- Ensure foreign key columns have NOT NULL constraints
+-- and remove any orphaned rows before applying the constraint.
+
+-- Clean up orphaned children and enforce parent relationship
+DELETE FROM children WHERE parent_id IS NULL;
+ALTER TABLE children
+  ALTER COLUMN parent_id SET NOT NULL;
+
+-- Clean up orphaned embeddings and enforce lesson relationship
+DELETE FROM embeddings WHERE lesson_id IS NULL;
+ALTER TABLE embeddings
+  ALTER COLUMN lesson_id SET NOT NULL;


### PR DESCRIPTION
## Summary
- remove orphaned children and require `children.parent_id`
- clean up embeddings without lessons and require `embeddings.lesson_id`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c39bbaffb48327b1263d035b44d37e