### PR TITLE
Derive lesson topic from OCR text

### DIFF
--- a/tests/test_extract_image_descriptions.py
+++ b/tests/test_extract_image_descriptions.py
@@ -3,7 +3,7 @@ import sys
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
-from app.tasks import extract_image_descriptions
+from app.tasks import extract_image_descriptions, derive_topic_from_text
 
 
 def test_extract_image_descriptions_frequency():
@@ -14,3 +14,13 @@ def test_extract_image_descriptions_frequency():
     result = extract_image_descriptions(text, max_items=3)
     assert result[:2] == ["ville", "chat"]
     assert len(result) == 3
+
+
+def test_derive_topic_from_text():
+    text = (
+        "Un chat noir et un chien marron dans une ville. "
+        "Le chat regarde la ville. La ville est belle."
+    )
+    topic, desc = derive_topic_from_text(text)
+    assert topic == "ville chat noir"
+    assert desc[:3] == ["ville", "chat", "noir"]


### PR DESCRIPTION
## Summary
- derive topic nouns from OCR text with `derive_topic_from_text`
- pass derived topic into `mimi.build_mimi_lesson` so lessons reflect source material
- cover topic derivation with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3a054bac88327ab2973c58b64edc8